### PR TITLE
Convert 404 response for empty tiles to a 200. 

### DIFF
--- a/endpoints/tables/views/table_dynamic_map.jade
+++ b/endpoints/tables/views/table_dynamic_map.jade
@@ -19,7 +19,7 @@ block content
 				var map = L.map('map');
 				var bounds = [[YMIN, XMIN], [YMAX, XMAX]]; //SouthWest, NorthEast (Lat Lon, Lat Lon) grr.
 					
-				L.tileLayer('http://{s}.tiles.mapbox.com/v3/examples.map-qfyrx5r8/{z}/{x}/{y}.png').addTo(map);
+				L.tileLayer('http://{s}.tiles.mapbox.com/v3/mapbox.world-blue/{z}/{x}/{y}.png').addTo(map);
 
 				//Add preview
 				L.tileLayer(mapUrl + '/{z}/{x}/{y}.png').addTo(map);

--- a/endpoints/tables/views/table_query.jade
+++ b/endpoints/tables/views/table_query.jade
@@ -189,7 +189,7 @@ block results
 							}
 
 							var map = L.map('map').setView([51.505, -0.09], 13);
-							L.tileLayer('http://{s}.tiles.mapbox.com/v3/examples.map-qfyrx5r8/{z}/{x}/{y}.png').addTo(map);
+							L.tileLayer('http://{s}.tiles.mapbox.com/v3/mapbox.world-blue/{z}/{x}/{y}.png').addTo(map);
 							previewLayer = L.geoJson(geojson).addTo(map);
 							map.fitBounds(previewLayer);
 					-}

--- a/endpoints/tables/views/table_vector_tiles.jade
+++ b/endpoints/tables/views/table_vector_tiles.jade
@@ -32,7 +32,7 @@ block content
                 var map = L.map('map');
                 var bounds = [[YMIN, XMIN], [YMAX, XMAX]]; //SouthWest, NorthEast (Lat Lon, Lat Lon) grr.
 
-                L.tileLayer('http://{s}.tiles.mapbox.com/v3/examples.map-qfyrx5r8/{z}/{x}/{y}.png').addTo(map);
+                L.tileLayer('http://{s}.tiles.mapbox.com/v3/mapbox.world-blue/{z}/{x}/{y}.png').addTo(map);
 
                 //Highly experimental Mapnik Vector Tiles PBFLayer
                 var pbfSource = new L.TileLayer.PBFSource({

--- a/endpoints/tiles/index.js
+++ b/endpoints/tiles/index.js
@@ -1572,10 +1572,10 @@ var createVectorTileRoute = exports.createVectorTileRoute = flow.define(
                 return;
               }
 
-              // Empty tiles are equivalent to no tile.
+              // Empty tiles are valid responses.
               if (_self._blank || !key) {
                 res.removeHeader('Content-Encoding');
-                res.writeHead(404, {
+                res.writeHead(200, {
                   'Content-Type': 'application/octet-stream'
                 });
 

--- a/endpoints/tiles/views/image_tile_dynamic_map.jade
+++ b/endpoints/tiles/views/image_tile_dynamic_map.jade
@@ -20,7 +20,7 @@ block content
             script.
                 var map = L.map('map');
 
-                L.tileLayer('http://{s}.tiles.mapbox.com/v3/examples.map-qfyrx5r8/{z}/{x}/{y}.png').addTo(map);
+                L.tileLayer('http://{s}.tiles.mapbox.com/v3/mapbox.world-blue/{z}/{x}/{y}.png').addTo(map);
 
                 //Add preview
                 L.tileLayer(mapUrl + '/{z}/{x}/{y}.png').addTo(map);

--- a/endpoints/tiles/views/tile_vector_dynamic_map.jade
+++ b/endpoints/tiles/views/tile_vector_dynamic_map.jade
@@ -33,7 +33,7 @@ block content
                 var map = L.map('map');
                 //var bounds = [[YMIN, XMIN], [YMAX, XMAX]]; //SouthWest, NorthEast (Lat Lon, Lat Lon) grr.
 
-                L.tileLayer('http://{s}.tiles.mapbox.com/v3/examples.map-qfyrx5r8/{z}/{x}/{y}.png').addTo(map);
+                L.tileLayer('http://{s}.tiles.mapbox.com/v3/mapbox.world-blue/{z}/{x}/{y}.png').addTo(map);
 
                 //Highly experimental Mapnik Vector Tiles PBFLayer
                 var pbfSource = new L.TileLayer.PBFSource({

--- a/endpoints/utilities/views/wktpreview.jade
+++ b/endpoints/utilities/views/wktpreview.jade
@@ -101,7 +101,7 @@ block results
 								}
 
 								var map = L.map('map').setView([51.505, -0.09], 13);
-								L.tileLayer('http://{s}.tiles.mapbox.com/v3/examples.map-qfyrx5r8/{z}/{x}/{y}.png').addTo(map);
+								L.tileLayer('http://{s}.tiles.mapbox.com/v3/mapbox.world-blue/{z}/{x}/{y}.png').addTo(map);
 								previewLayer = L.geoJson(geojson).addTo(map);
 								map.fitBounds(previewLayer);
 						-}


### PR DESCRIPTION
Many vector-tile data sets have empty tiles.  The 404 response for such tiles is cluttering the console in the apps that are receiving such tiles.  Return a 200 status instead - the resource has been found, it just happens to be empty.

Also, update the mapbox basemap mapbox.world-blue.  Had been receiving 401 response for the older examples.map-qfyrx5r8.